### PR TITLE
Point Python itertools link to latest 3.x version

### DIFF
--- a/itertools.lua
+++ b/itertools.lua
@@ -39,7 +39,7 @@
 -- -------
 --
 -- This module is loosely based on [Python's itertools
--- module](https://docs.python.org/3.5/library/itertools.html), plus some
+-- module](https://docs.python.org/3/library/itertools.html), plus some
 -- other of Python's built-ins like [map()](https://docs.python.org/3/library/functions.html?highlight=map#map)
 -- and [filter()](https://docs.python.org/3/library/functions.html?highlight=filter#filter).
 --


### PR DESCRIPTION
/3.5/ will always go to the Python 3.5 docs, even after it is no longer the current version (which will become the case in December). This fixes it to always go to the latest 3.x version, just like the other two links in that paragraph.
